### PR TITLE
Removed relay-specific usage of "action" to simplify terminology

### DIFF
--- a/docs/adding-an-approval-step.md
+++ b/docs/adding-an-approval-step.md
@@ -2,7 +2,7 @@
 
 Add manual approvals to your Relay workflow when you need more control over when something is deployed. For example, you could prevent a deployment to your production environment without an approval from your engineering lead.
 
-After you add an approval to your workflow, an approver can accept or reject it from the workflow run page in the Relay web interface. To approve actions, the user must have Approver or Administrator level of access.
+After you add an approval to your workflow, an approver can accept or reject it from the workflow run page in the Relay web interface. To respond to an approval request, the user must have Approver or Administrator level of access.
 
 Approvals are similar to regular steps, although they do not require an `image` key. Approvals consist of the following keys:
 
@@ -10,15 +10,15 @@ Approvals are similar to regular steps, although they do not require an `image` 
 
 -   `description`: A string. A description of your approval.
 
--   `type`: A string. Use `approval` to define the step as an approval action.
+-   `type`: A string. Use `approval` to define the step as an approval.
 
 -   `dependsOn`: A string, or an array of strings. (Optional) The steps that need to complete successfully before Relay requests the approval.
 
 An approval that does not list a dependency under `dependsOn` can be approved or rejected at any time. An approval that does list dependencies can only be approved once those dependencies have successfully completed.
 
-A step that immediately follows your approval should list the approval step as a dependency using `dependsOn.` Multiple actions can depend on a single approval.
+A step that immediately follows your approval should list the approval step as a dependency using `dependsOn.` Multiple steps can depend on a single approval.
 
-An example of an approval action with a `deploy-prod` step that depends on it:
+An example of an approval with a `deploy-prod` step that depends on it:
 
 ```yaml
 steps:

--- a/docs/integrating-with-relay.md
+++ b/docs/integrating-with-relay.md
@@ -4,16 +4,16 @@ There's a growing [ecosystem of integrations](https://relay.sh/integrations/) th
 
 ## Decide on a goal
 
-This may seem self-evident, but it's important to determine what your goal is _before_ you begin coding. Relay has several useful points of extensibility, and understanding the purpose of each will help you find a starting point. Integrations consist of containers that are used in different parts of Relay; the umbrella term is **Actions**, and they're further specialized into **steps** and **triggers**.
+This may seem self-evident, but it's important to determine what your goal is _before_ you begin coding. Relay has several useful points of extensibility, and understanding the purpose of each will help you find a starting point. Integrations consist of containers that are used in different parts of Relay, which have two flavors: **steps** and **triggers**.
 
 * **Steps** - Relay runs steps, passing in parameters and secrets, as part of an automation workflow. Most of the work in Relay is done by Steps, which use an SDK to retrieve and modify a workflow's state as it executes.
 * **Triggers** - Relay supports several [types of triggers](./reference/relay-workflows.md#Triggers), which are event handlers that initiate workflow runs. The Relay service handles `push` triggers natively, but `webhook` triggers work by executing a user-defined container to handle the payload of the webhook's incoming HTTP request. Therefore, integrations that connect to Relay using webhooks need to provide a Trigger container.
 
-Actions come together in Workflows, YAML code written to accomplish the task you're faced with. Workflow authoring is covered in the [Using workflows](./using-workflows.md) documentation, so here we'll focus on creating and using Step and Trigger Actions.
+Steps and Triggers come together in Workflows, YAML code written to accomplish the task you're faced with. Workflow authoring is covered in the [Using workflows](./using-workflows.md) documentation, so here we'll focus on creating and using Steps and Triggers.
 
-## Creating Actions
+## Creating Containers for Relay
 
-In its simplest form, a Relay action is a container image which runs, does some work, and then exits. It's possible to use any OCI-compliant container, as long as its entrypoint terminates with a `0` exit code upon success and a non-zero code upon failure. However, beyond "hello world" examples you'll likely want an image with more capabilities than just using `alpine:latest`. There are two possible paths here, depending on your use case.
+In its simplest form, a Relay container image runs, does some work, and then exits. It's possible to use any OCI-compliant container, as long as its entrypoint terminates with a `0` exit code upon success and a non-zero code upon failure. However, beyond "hello world" examples you'll likely want an image with more capabilities than just using `alpine:latest`. There are two possible paths here, depending on your use case.
 
 1. If the work you're trying to do can be written in a shell or Python script, use the `relaysh/core` image. This is an Alpine-based image that the Relay team maintains, which comes pre-loaded with the Relay SDK. There are `relaysh/core:latest` and `relaysh/core:latest-python` flavors available. You can use these either as a base image in your own Dockerfile or in workflows directly, by specifying an `inputFile` tag whose value is a URL to your script.
 2. If there's an existing image that's made for your integration target, you can use it as the starting point for a custom container. Adding the Relay tools in at build time will allow you to use the metadata service via either the command-line interface or code SDK.
@@ -26,7 +26,7 @@ There are two variants of `relaysh/core`, indicated by their tag: `relaysh/core:
 
 #### relaysh/core Shell Example
 
-Because webhook Trigger containers need to handle a web request, the shell image isn't suitable for trigger actions, only steps.
+Because webhook Trigger containers need to handle a web request, the shell image isn't suitable for triggers, only steps.
 
 ```yaml
 steps:
@@ -134,7 +134,7 @@ Under the hood, when a workflow references a webhook trigger, the Relay app will
 * If so, map values from the request payload onto event data
 * Finally, send this mapping back into the Relay service as an event
 
-The Relay Python SDK is by far the easiest way to do this. The [Integration template repository](https://github.com/relay-integrations/template/) has a simple starting point, and there are full-featured examples for [Dockerhub push events](https://github.com/relay-integrations/relay-dockerhub/blob/master/actions/triggers/image-pushed/handler.py) and [new Pagerduty incidents](https://github.com/relay-integrations/relay-pagerduty/blob/master/actions/triggers/incident-triggered/handler.py). Check out the [Relay integrations on Github](https://github.com/relay-integrations/) for more ideas.
+The Relay Python SDK is by far the easiest way to do this. The [Integration template repository](https://github.com/relay-integrations/template/) has a simple starting point, and there are full-featured examples for [Dockerhub push events](https://github.com/relay-integrations/relay-dockerhub/blob/master/triggers/image-pushed/handler.py) and [new Pagerduty incidents](https://github.com/relay-integrations/relay-pagerduty/blob/master/triggers/incident-triggered/handler.py). Check out the [Relay integrations on Github](https://github.com/relay-integrations/) for more ideas.
 
 #### Step entrypoints
 
@@ -146,11 +146,11 @@ Steps have a relatively easy lot in life. They run, do some work to advance the 
 * Exiting with a zero exit code will cause the workflow run to continue
 * Exiting with a non-zero exit code will cause the workflow run to be terminated and no dependent steps will run
 
-For examples of using the `ni` utility in shell commands, see the [kustomize integration](https://github.com/relay-integrations/relay-kustomize/blob/master/actions/steps/kustomize/step.sh); for examples of using the Python SDK, the [AWS EC2 integration](https://github.com/relay-integrations/relay-aws-ec2/tree/master/actions/steps) has several steps of varying complexity.
+For examples of using the `ni` utility in shell commands, see the [kustomize integration](https://github.com/relay-integrations/relay-kustomize/blob/master/steps/kustomize/step.sh); for examples of using the Python SDK, the [AWS EC2 integration](https://github.com/relay-integrations/relay-aws-ec2/tree/master/steps) has several steps of varying complexity.
 
-### Building and publishing actions
+### Building and publishing containers
 
-Once you've got your base image and custom code together, you can proceed with building and publishing the action containers. Relay has conventions for container and integration metadata which aren't _required_ but will increase consistency and help with future compatibility. These conventions are encoded in the [template integration repo](https://github.com/relay-integrations/template), specifically:
+Once you've got your base image and custom code together, you can proceed with building and publishing the containers. Relay has conventions for container and integration metadata which aren't _required_ but will increase consistency and help with future compatibility. These conventions are encoded in the [template integration repo](https://github.com/relay-integrations/template), specifically:
 
 <!-- * Integration repos should have an `integration.yaml` at their root, whose structure is defined in the [Integration RFC](TODO:link). -->
 * Relay containers should be built with LABEL directives that indicate their title and description.

--- a/docs/reference/relay-types.md
+++ b/docs/reference/relay-types.md
@@ -4,7 +4,7 @@ Relay's workflow dialect uses YAML "tag" notation, indicated by a `!`, to identi
 
 ## !Connection
 
-Most actions require some form of authentication. `!Connection` provides a way to add service credentials to the workflow that are required by a Relay action. Actions that require a `!Connection` in order to run can be configured as follows:
+Most workflows require some form of authentication. `!Connection` provides a way to add service credentials to your account, which all workflows in your account can access. Workflows that require a `!Connection` in order to run can access it like this:
 
 ```yaml
 - name: describe-instances
@@ -19,9 +19,11 @@ Then, add the required credentials for the Connection (in the example: `my-aws-a
 
 Connections can be reused across Workflows. Referencing the same `!Connection` by name in another workflow will automatically use the defined connection.
 
+See also the documentation on [Adding Connections to your Workflow](../using-workflows/adding-connections.md).
+
 ## !Secret
 
-Use this to indicate the value is a named secret that's stored on the service. The value needs to exactly match the secret name. If the secret doesn't exist, the workflow will not run. Secrets are scoped to a single workflow.
+Use this to indicate the value is a named secret that's stored on the service. The value needs to exactly match the secret name. If the secret doesn't exist, the workflow will not run. Unlike Connections, Secrets are scoped to a single workflow.
 
 The most common usage for `!Secret` is in the `spec` for a given step, to indicate the value needs to be looked up from the secret store:
 
@@ -34,7 +36,6 @@ steps:
 ```
 
 See the section on [adding and managing secrets](../using-workflows/adding-secrets.md) for more detail on secrets in Relay.
-
 
 ## !Parameter
 

--- a/docs/step-specifications.md
+++ b/docs/step-specifications.md
@@ -2,6 +2,6 @@
 
 There are a number of Relay containers available that you that can use in your workflows. For a full list of available containers and their tags, see [relaysh on Docker Hub](https://hub.docker.com/u/relaysh).
 
-To see the source code for the containers, or contribute your own actions, see the [Relay integrations](https://github.com/relay-integrations) organization on GitHub. 
+To see the source code for the containers or contribute your own, see the [Relay integrations](https://github.com/relay-integrations) organization on GitHub. 
 
 The [Integrating with Relay](integrating-with-relay.md) documentation has detailed technical information about how to develop your own step and trigger containers.

--- a/docs/using-workflows/adding-connections.md
+++ b/docs/using-workflows/adding-connections.md
@@ -25,7 +25,7 @@ steps:
 
 If you reference a Connection in a workflow you're viewing or editing on the web app, Relay will check that the connection actually exists and prompt you to create it if not. To set the required values for the connection, on the workflow's page, expand the "Setup" menu on the header bar, then find the connection you specified. Click the ( + ) to add the connection values. Once you create a connection, you cannot view its values again; you can only overwrite or delete them.
 
-When you run a workflow, actions that need a connection request it from Relay's secret store. You can use secrets inside an action with one of the Relay SDKs. This example snippet uses the Python SDK to make use of the connection in the workflow above:
+When you run a workflow, steps that need a connection request it from Relay's secret store. You can use secrets inside a step with one of the Relay SDKs. This example snippet uses the Python SDK to make use of the connection in the workflow above:
 
 ```python
 from nebula_sdk import Interface, Dynamic as D
@@ -37,7 +37,7 @@ sess = boto3.Session(
   region_name=relay.get(D.aws.region),
 )
 ```
-This is a partial snippet; [see the full step code here](https://github.com/relay-integrations/relay-aws-ec2/blob/master/actions/steps/ec2-describe-instances/step.py).
+This is a partial snippet; [see the full step code here](https://github.com/relay-integrations/relay-aws-ec2/blob/master/steps/ec2-describe-instances/step.py).
 
 ## Implementation details
 

--- a/docs/using-workflows/adding-secrets.md
+++ b/docs/using-workflows/adding-secrets.md
@@ -24,7 +24,7 @@ steps:
       credentials: !Secret credentials
 ```
 
-When workflows run, actions that require a secret request the secret value from the Relay secrets service. Inside a step, the `ni` command-line tool or SDKs can access secret values like regular values:
+When workflows run, steps that require a secret request the secret value from the Relay secrets service. Inside a step, the `ni` command-line tool or SDKs can access secret values like regular values:
 
 ```
 USERNAME="${USERNAME:-$(ni get -p '{.username}')}"
@@ -33,15 +33,15 @@ PASSWORD="${PASSWORD:-$(ni get -p '{.credentials}')}"
 
 ## Implementation details
 
-Relay implements Secrets and [Connections](./adding-connections.md) similarly. Relay encrypts secrets when you create them and stores them encrypted in a secure service backed by [Hashicorp Vault](https://www.vaultproject.io). The permissions between Relay's services are set up so the user-facing APIs and the web app can create, overwrite, or delete, but never display them. The service which provides metadata to workflow runs can view but not change secrets, so they're visible to the action containers as workflows execute.
+Relay implements Secrets and [Connections](./adding-connections.md) similarly. Relay encrypts secrets when you create them and stores them encrypted in a secure service backed by [Hashicorp Vault](https://www.vaultproject.io). The permissions between Relay's services are set up so the user-facing APIs and the web app can create, overwrite, or delete, but never display them. The service which provides metadata to workflow runs can view but not change secrets, so they're visible to the containers as workflows execute.
 
 There are some important differences between secrets and connections.
 * Secrets are scoped to a workflow and no other workflow can access another workflow's secrets, whereas connections are reusable across workflows.
 * Secrets consist of a single string key/value pair which can be named anything that makes sense for the workflow which uses them. Connections can have a user-specified name, but the structure of them is always consistent, to enable reuse. For example, an `aws` connection will always have an `accessKeyID` field, whereas an `azure` connection will always have a `subscriptionID`.
 
-As any action can request secrets, it pays to be cautious:
+As any step can request secrets, it pays to be cautious:
 - Be extra careful when printing output in steps which use secrets. Steps have plaintext access to secrets and credentials, so "echo" or "printf" debugging steps can accidentally leak their values.
 - When creating credentials to access an external service, grant the minimum necessary credentials for the workflow to run.
 - Because the contents will be encrypted, it helps to make meaningful names for connections which indicate which account/role they are associated with.
 - Use service accounts over personal credentials where possible.
-- Understand the code for every action running in the workflow. Relay action source code can be found within the [Relay Integrations organization](https://github.com/relay-integrations)
+- Understand the code for every step running in the workflow. Source code for Puppet-curated containers lives in the [Relay Integrations organization](https://github.com/relay-integrations)


### PR DESCRIPTION
Incorporating feedback, both internal and external, that having
the term-of-art "action", of which "steps" and "triggers" are
sub-types, was confusing to people. This eliminates it from the
docs seems to have cleaned up the language commesurately.