### PR TITLE
Editing pass

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,4 +1,4 @@
-# CLI Documentation
+# CLI documentation
 
 There are two command-line programs for interacting with Relay. Their auto-generated documentation is stored here for reference.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
-# Getting Started with Relay
+# Getting started with Relay
 
-This is a guided tour to walk you through getting started with Relay. It takes about 15 minutes to complete. By the end of it, you'll be able to use the service to automate tasks of your own, replacing digital duct tape with reusable, on-demand workflows.
+This is a guided tour to walk you through getting started with Relay. It takes about 15 minutes to complete. By the end of the guide, you'll be able to use the service to automate tasks of your own, replacing digital duct tape with reusable, on-demand workflows.
 
 ## Create an account
 
@@ -8,9 +8,9 @@ First things first. You'll need an account on the service to get started, so bro
 
 ## Create a simple workflow
 
-Relay is based around the idea of Workflows, which combine useful activites together to accomplish a specific task. Workflows are written in YAML and stored on the service so they can be triggered manually or via incoming events. Let's start by creating a simple "Hello World" workflow that just executes an "echo" command with any argument you give it.
+Relay is based around the idea of workflows, which combine useful activities together to accomplish a specific task. Workflows are written in YAML and stored on the service so they can be triggered manually or via incoming events. Let's start by creating a simple "Hello World" workflow that just executes an `echo` command with any argument you give it.
 
-Click the **Add workflow** button in the top right corner. In the dialog box, give it a name of `hello-world` and a description "Welcome to Relay". You'll get dropped into an editor window, where you can copy-and-paste the following workflow, then click the "Save changes" button on the top right of the editor window.
+Click the **New workflow** button in the top right corner. In the dialog box, give it a name of `hello-world` and a description "Welcome to Relay". You'll get dropped into an editor window, where you can copy-and-paste the following workflow, then click the **Save changes** button on the top right of the editor window.
 
 ```yaml
 parameters:
@@ -25,23 +25,25 @@ steps:
   - echo "Hello world. Your message was $(ni get -p {.message})"
 ```
 
-This workflow starts by defining a parameter named `message`, whose value you'll need to supply before the workflow starts. Then it defines a step named `hello-world`, using a container image stored on Docker hub at [`relaysh/core`](https://hub.docker.com/r/relaysh/core), which is a general-purpose Alpine Linux based image curated by Puppet.
+This workflow starts by defining a parameter named `message`, whose value you'll need to supply before the workflow starts. Then it defines a step named `hello-world`, using a container image stored on Docker Hub at [`relaysh/core`](https://hub.docker.com/r/relaysh/core), which is a general-purpose Alpine Linux based image curated by Puppet.
 
-The `spec` map defines keys and their values that will be available inside the step. In this case, we're looking up the value of the global `message` parameter and making it available to the container. Other options besides the `!Parameter` include `!Secret` for accessing encrypted values and a number of utility functions like `!Merge` and `!Concat`.
+The `spec` map defines keys and their values that will be available inside the step. In this case, we're using the Relay `!Parameter` type to look up the value of the global `message` parameter and make it available to the container. 
 
-The container is executed with the value of the `input` step as its entrypoint. The "Hello world" message uses a command-line tool built for Relay called `ni` to inject the value of the message parameter into its output.
+**TIP:** In addition to `!Parameter`, Relay has several types that you can use in your workflows. For example, you can use `!Secret` to access encrypted values. You also have access to several utility functions like `!Merge` and `!Concat` that allow you to perform logic in your workflows.
 
-> Further reading: [Function reference](./reference/relay-functions.md), [Relay integrations](https://github.com/relay-integrations), [ni documentation](./cli/ni.md)
+Relay executes the container with the value of the `input` step as its entrypoint. The "Hello world" message uses a command-line tool built for Relay called `ni` to inject the value of the message parameter into its output.
+
+> Further reading: [Relay types](./reference/relay-types.md) [Relay functions](./reference/relay-functions.md), [Relay integrations](https://github.com/relay-integrations), [ni documentation](./cli/ni.md)
 
 ## Run it via the GUI
 
-Once you save the workflow, use the "Run" button in the top right to execute it. You'll get a dialog box prompting you to fill in the value of the "message" parameter, so enter something witty (if you need a suggestion, try "relay.sh r00lz"), then click "Run workflow".
+Once you save the workflow, use the **Run** button in the top right to execute it. You'll get a dialog box prompting you to fill in a value for the **messag** parameter, so enter something witty (if you need a suggestion, try "relay.sh r00lz"), then click **Run workflow**.
 
-Your workflow run will be queued on the service and then executed. You'll see some statistics and a graph visualization of the step sequence. With only one step, this workflow's graph just has one node represented as a box; click it to see the step's details in the sidebar.
+Relay will queue your workflow run and then execute it. You'll see some statistics and a graph visualization of the step sequence. Because it only has one step, this workflow's graph has one node represented as a box; click it to see the step's details in the sidebar.
 
-Once the step completes, you can select the "Code and data" tab to show the workflow code we just wrote and expand the collapsed right sidebar to show the input for the "message" parameter.
+Once the step completes, you can select the **Code and data** tab to show the workflow code we just wrote and expand the collapsed right sidebar to show the input for the **message** parameter.
 
-Select the "Logs" tab to see the earth-shattering results of your workflow run.
+Select the **Logs** tab to see the earth-shattering results of your workflow run.
 
 > Further reading: [Example workflows](https://github.com/puppetlabs/relay-workflows), [Passing data into workflows](using-workflows/passing-data-into-workflow-steps.md)
 
@@ -49,7 +51,7 @@ Select the "Logs" tab to see the earth-shattering results of your workflow run.
 
 The web app is great for visualization, log history, and troubleshooting. For workflow editing and authoring, however, you'll almost certainly want to use the command-line interface, `relay`.
 
-You can grab the latest release from the [puppetlabs/relay github site](https://github.com/puppetlabs/relay/releases); it's a single binary download so download the latest release for your operating system, install it into your $PATH, and make it executable.
+You can grab the latest release from the [puppetlabs/relay GitHub site](https://github.com/puppetlabs/relay/releases); it's a single binary download so download the latest release for your operating system, install it into your `$PATH`, and make it executable.
 
 For easy installation and updating on a Mac, you can use [Homebrew](https://brew.sh):
 
@@ -58,9 +60,9 @@ brew install puppetlabs/puppet/relay
 ```
 We also have packaging scripts for [Arch Linux](https://github.com/puppetlabs/relay/blob/master/build/package/archlinux/PKGBUILD) and welcome additional packaging contributions!
 
-## Download the workflow
+## Download your workflow
 
-With the CLI installed, you can use it to authenticate to your account and operate on workflows. Running `relay` by itself will show the list of available subcommands, and you can run any subcommand with the `--help` option to get detailed usage information. Log yourself in, get a list of your available workflows, and download the `hello-world` workflow we created earlier to a local file using the following commands:
+With the CLI installed, you can use it to authenticate to your account and operate on workflows. Running `relay` by itself will show the list of available subcommands, and you can run any subcommand with the `--help` option to get detailed usage information. Use the following commands to log in, get a list of your available workflows, and download the `hello-world` workflow we created earlier to a local file:
 
 ```
 relay auth login yourname@yourdomain.io
@@ -70,7 +72,7 @@ relay workflow download hello-world > hello-world.yaml
 
 > Further reading: [Set up your code editor](setting-up-editor.md), [Relay CLI repository](https://github.com/puppetlabs/relay/)
 
-## Modify it to pass data between steps
+## Modify the workflow to pass data between steps
 
 Relay executes each step in a workflow as a separate container. This allows you to link together smaller, built-to-purpose containers that each accomplish a concrete task rather than putting everything into one big script. Modular components increase reusability, but they do present more of a challenge to pass state information between steps.
 
@@ -96,17 +98,17 @@ steps:
   - echo "Hello world. Your message was $(ni get -p {.message}), and the generated output was $(ni get -p {.dynamic})"
 ```
 
-We've added a `generated-output` step which uses the `ni` utility to set the value of a key named `dynamic` with the output of the `/bin/date` program. The spec for the `hello-world` step looks up that value with the `!Output` function and makes it available inside the step for `ni` to read.
+We've added a `generated-output` step which uses the `ni` utility to set the value of a key named `dynamic` with the output of the `/bin/date` program. The spec for the `hello-world` step uses the `!Output` type to look up the value for `dynamic`, and make it available inside the step for `ni` to read.
 
-## Update and run it via the CLI
+## Update and run the workflow via the CLI
 
-Don't forget to save your work! You've got it stored locally, but you'll need to update the version that lives on the Relay service. Relay keeps your workflows in cloud storage and always runs the latest version you've uploaded. It's a good idea to use git to keep your workflows under revision control using git, but for now we can just replace the previous version with our updates using the CLI:
+Don't forget to save your work! You've got it stored locally, but you'll need to update the version that lives on the Relay service. Relay keeps your workflows in cloud storage and always runs the latest version you've uploaded. It's a good idea to use git to keep your workflows under revision control, but for now, we can just replace the previous version with our updates using the CLI:
 
 ```
 relay workflow replace hello-world -f hello-world.yaml
 ```
 
-Then we can trigger a run, supplying the `message` parameter using the `-p` flag. When you have a workflow that takes multiple parameters, you can use several `-p` (or `--parameter`, if you really like typing!) flags in a row.
+Now, run the workflow, supplying the `message` parameter using the `-p` flag. When you have a workflow that takes multiple parameters, you can use several `-p` (or `--parameter`, if you really like typing!) flags in a row.
 
 ```
 relay workflow run hello-world -p message="Run from CLI"
@@ -114,13 +116,13 @@ relay workflow run hello-world -p message="Run from CLI"
 
 The output of this command will include a URL that you can open in your web browser to watch the progress of the run. Under the hood, Relay figured out that, because of the `!Output` tag, the `hello-world` step now has a _dependency_ on the `generated-output` step. So the graph now represents that ordering. You can also use an explicit `dependsOn: step-name` key in a step's definition to force ordering. Without ordering information, Relay will run the steps in parallel to speed up the workflow execution.
 
-> Further reading: [Types reference](reference/relay-types.md), [relay CLI reference](./cli/relay.md), [Complex "Sock Shop" workflow](https://github.com/puppetlabs/relay-workflow-examples/tree/master/aks-sock-shop).
+> Further reading: [Relay types](reference/relay-types.md), [relay CLI reference](./cli/relay.md), [Complex "Sock Shop" workflow](https://github.com/puppetlabs/relay-workflow-examples/tree/master/aks-sock-shop).
 
-## Modify Workflow to add a secret
+## Modify workflow to add a secret
 
-Relay's secret management is one of the most significant advantages of the service over running scripts from your laptop. It keeps sensitive data like passwords and credentials securely stored in Hashicorp Vault and decrypts them for the duration of a workflow run. Eliminating password sprawl and hardcoded API keys reduces risk and increases the reusability of workflows.
+Secret management is one of the most significant advantages to using Relay over running scripts from your laptop. Relay keeps sensitive data like passwords and credentials securely stored in Hashicorp Vault and decrypts them for the duration of a workflow run. Eliminating password sprawl and hardcoded API keys reduces risk and increases the reusability of workflows.
 
-Let's modify our `hello-world` workflow one last time to add a placeholder secret and supply that value. In the web app, edit your `hello-world` step to look like the following:
+Let's modify our `hello-world` workflow one last time to add a placeholder secret and supply that value. In the web app, click on the **Code** tab and edit your `hello-world` step to look like the following:
 
 ```yaml
 - name: hello-world
@@ -134,14 +136,14 @@ Let's modify our `hello-world` workflow one last time to add a placeholder secre
   - echo "Normally I would never say this, but your secret was $(ni get -p {.supersecret})"
 ```
 The `ni` utility can access secrets just like regular parameters, but you wouldn't generally want to echo them to the logs as in this example!
-When you click "Save changes", you'll see a warning dialog that you're missing a required secret, and a prompt to fill it in. Follow the link in the prompt to open the Workflow Setup sidebar and enter a secret value. Keep in mind that secrets can be deleted and re-added, but never viewed.
+When you click **Save changes**, you'll see a warning dialog that you're missing a required secret, and a prompt to fill it in. Follow the link in the prompt to open the **Setting** sidebar. Click the **+** icon and enter a secret value. Secrets can be deleted and re-added, but never viewed.
+
+Congratulations! You now have a running example that exercises many of Relay's useful features:
+
+* The Relay web app shows all the workflows in your account and keeps detailed logs of their execution history.
+* You can use the `relay` cli to develop workflows locally, trigger parameterized runs, and add, delete or replace the workflows stored on the Relay service. 
+* You can securely store sensitive data like API keys and passwords using the `!Secret` key and secret management sidebar.
 
 ## Next steps...
 
-Now you've got a running example that exercises many useful features of the system:
-
-* the Relay web app shows all the workflows in your account and keeps details logs of their execution history
-* the `relay` cli can be used to develop workflows locally, add / delete / replace them on the service, and trigger parameterized runs
-* the `!Secret` key and secret management sidebar let you keep sensitive data like API keys and passwords on the service securely.
-
-For next steps, check out the [Workflow Library](https://relay.sh/workflows/) for more real-world examples that you can easily add to your account and modify to suit your needs. Happy automating! 🤖
+Check out the [Workflow library](https://relay.sh/workflows/) for more real-world examples that you can easily add to your account and modify to suit your needs. Happy automating! 🤖

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,77 +1,77 @@
-## How Relay Works
+## How Relay works
 
-If you've read through the [website](https://relay.sh) and followed the [Getting Started guide](getting-started.md), you might be thinking: "This is pertty cool, but how does it _actually work_ under the hood?" This document is aimed at answering that question at a middle-altitude level of technical depth. You'll have a better understanding of the architecture of the Relay service and how the pieces fit together, as a prelude to diving into the [reference documentation](reference.md) or beginning to build [a custom Relay integration](integrating-with-relay.md).
+If you've read through the [website](https://relay.sh) and followed the [Getting Started guide](getting-started.md), you might be thinking: "This is pretty cool, but how does it _actually work_ under the hood?" This document is aimed at answering that question at a middle-altitude level of technical depth. You'll have a better understanding of the architecture of the Relay service and how the pieces fit together, as a prelude to diving into the [reference documentation](reference.md) or beginning to build [a custom Relay integration](integrating-with-relay.md).
 
 ## Definitions
 
-While we've tried to keep the tool-specific jargon to a minimum, there are inevitably some terms that have specific meanings in the context of the Relay system. Here are definitions for the most common ones:
+While we've tried to keep the tool-specific jargon to a minimum, there are inevitably some terms that have specific meanings in the context of the Relay system. Here are definitions for the most common terminology:
 
-* **Steps** - Relay runs steps, passing in parameters and secrets, as part of an automation workflow.
-* **Triggers** - External systems send data to Relay, which handles them by executing a Trigger. The code inside the Trigger determines how to respond to the event.
-* **Workflow** - a collection of triggers, sequenced steps, parameters, and metadata that's meant to accomplish a particular task.
-* **Event** - a message sent into the Relay service by a Trigger to start running a workflow.
-* **Integration** - Collection of step and trigger container definitions that all work with a common service or tool, such as PagerDuty, Slack, AWS EC2, Terraform.
-* **Connection** - An authentication instance to a service, such as an API token, security credential, username/password combo, etc. You can create multiple connections of the same kind– each differentiated by a user-friendly name. Examples include Slack accounts, AWS accounts, GitHub accounts, etc.
+* **Step** - Relay runs steps, passing in parameters and secrets, as part of an automation workflow.
+* **Trigger** - External systems send data to Relay, which handles them by executing a Trigger. The code inside the Trigger determines how to respond to the event.
+* **Workflow** - A collection of triggers, sequenced steps, parameters, and metadata that's meant to accomplish a particular task.
+* **Event** - A message sent into the Relay service by a Trigger to start running a workflow.
+* **Integration** - A collection of step and trigger container definitions that all work with a common service or tool, such as PagerDuty, Slack, AWS EC2, Terraform.
+* **Connection** - An authentication instance to a service, such as an API token, security credential, username/password combo, etc. You can create multiple connections of the same kind, each differentiated by a user-friendly name. Examples include Slack accounts, AWS accounts, and GitHub accounts.
 
-## Architectural Overview
+## Architectural overview
 
-At its heart, Relay is a system for running workflows, which are ordered series of container executions, in response to events, which are messages that come in to the system from the outside world.
+At its heart, Relay is a system for running workflows, which are ordered collections of container executions, in response to events, which are messages that come in to the system from the outside world.
 
-Let's walk through the lifecycle of a workflow run, following this block architecture diagram. (Note this is not an exhaustive picture of the system; we're glossing over some systems like authentication, queuing, and storage to focus on the parts user workflows interact with the most.)
+For the moment, let's ignore some of the internal intricacies of Relay (such as authentication, queuing, and storage) and walk through the lifecycle of a workflow run, following this block architecture diagram.
 
 ![Simplified relay architecture diagram](images/relay-architecture.png)
 
-## Events and Triggers
+## Events and triggers
 
 A workflow run begins with an event, which can come from a few distinct sources.
 
 If you've defined a [webhook trigger](reference/relay-workflows.md#webhook) on your workflow, Relay builds a unique URL for the remote service to call back on. In response to an incoming webhook payload, Relay executes a container defined in the workflow and dispatches the payload to it. The container's job is to decide whether to act on the webhook event and, if so, to dispatch an event back to the API to start the workflow.
 
-The API server also receives events from [push triggers](reference/relay-workflows.md#push) in addition to CLI and web app interactions where a user initiates the workflow run directly. If your workflow uses a push trigger, Relay generates a JWT authentication token that's uniquely associated with that workflow. For interactive runs, the user is responsible for providing parameter values, whereas triggers use the [`!Data` function](reference/relay-functions.md#data) to bind data from the incoming message to workflow parameter values.
+The API server receives events from [push triggers](reference/relay-workflows.md#push) in addition to CLI and web app interactions where you initiate the workflow run directly. If your workflow uses a push trigger, Relay generates a JWT authentication token that's uniquely associated with that workflow. For interactive runs, whoever triggered the workflow run is responsible for providing parameter values, whereas push triggers use the [`!Data` type](reference/relay-types.md#data) to bind data from the incoming message to workflow parameter values.
 
-There's also support for scheduled triggers, which generate an event at [crontab-style time intervals](reference/relay-workflows.md#schedule). This provides a simple, useful way to run a workflow on a recurring basis, with the drawback that you can't provide dynamic data into the workflow.
+Relay also supports scheduled triggers, which generate an event at [crontab-style time intervals](reference/relay-workflows.md#schedule). This provides a simple, useful way to run a workflow on a recurring basis, with the drawback that you can't provide dynamic data to the workflow.
 
 ## Workflow execution
 
-Workflows are written in YAML, which Relay interprets and stores on the service. Workflow files define both the triggers which activate them and the steps that ought to run to get the work done. Workflows are also parameterized, to make them more flexible. Workflows run on Kubernetes using [Tekton pipelines](https://tekton.dev) to manage ordering, lifecycle, and error handling.
+Workflows are written in YAML, which Relay interprets and stores. Workflow files define both the triggers which activate them and the steps that ought to run to get the work done. Workflows are also parameterized, to make them more flexible. Workflows run on Kubernetes using [Tekton pipelines](https://tekton.dev) to manage ordering, lifecycle, and error handling.
 
 An important part of each `step` definition in a workflow is its `spec`, short for "specification". This is a map of keys and values which Relay's metadata service makes available to the step container's runtime. A spec can contain a mixture of parameter values, computed strings (for example, using the [`!Fn.concat` function](reference/relay-functions.md#concat)), and secrets. The most important thing to note is that data won't be visible to the step container without being enumerated in the spec. A step may publish a `spec` definition, in the form of a JSON Schema, that forms its API contract with a workflow.
 
-As each step runs, it modifies the outside world by communicating with downstream tools and services. This frequently requires authentication credentials and secrets, which Relay stores in HashiCorp Vault and makes available (through the spec) to steps which need them. For more on the internals of secret storage and retrieval, check out the [Implementation details section of the Secret reference](using-workflows/adding-secrets#implementation-details).
+As each step runs, it modifies the outside world by communicating with downstream tools and services. This frequently requires authentication credentials and secrets, which Relay stores in Hashicorp Vault and makes available (through the `spec`) to steps which need them. For more on the internals of secret storage and retrieval, check out the [Implementation details section of the secret reference](using-workflows/adding-secrets#implementation-details).
 
-Steps also emit log output back to the service, including errors and failures. The failure of any step (indicated by a non-zero exit code from its entrypoint) will cause the workflow run to stop, allowing any currently executing steps to complete and causing any further pending steps to be skipped. The log output is stored in the service for historical auditing and troubleshooting.
+Steps also emit log output back to the service, including errors and failures. The failure of any step (indicated by a non-zero exit code from its entrypoint) will cause the workflow run to stop. Relay will skip any later steps which depended on the failed step. If the workflow uses [conditional logic](using-workflows/conditionals.md), parallel steps and non-dependent branches will continue to run to completion. The log output is stored in the service for historical auditing and troubleshooting.
 
 ## Security
 
 ### Where and how is my data stored?
 
-Relay uses Google Cloud Platform for its backend service and stores data encrypted-at-rest in Google Cloud SQL and Google Cloud Storage. Sensitive data is stored in HashiCorp Vault, which is configured to have a write-only trust relationship with the user-facing APIs; once encrypted, data can only be deleted or replaced and not read. Behind the scenes, a Kubernetes controller manages grants to the underlying Vault service so secrets can be used in workflows.
+Relay uses Google Cloud Platform (GCP) for its backend service and stores unencrypted data in GCP database products: Redis, Cloud SQL, and Google Cloud Storage. Encrypted data is stored in Hashicorp Vault, which is configured to have a write-only trust relationship with the user-facing APIs; once encrypted, data can only be deleted or replaced and not read.
 
 ### How do you keep Relay secure?
 
 Your security and privacy is a top priority for us. We:
 
-* conform to regulatory requirements for personally-identifable information (PII)
-* manage an escalation policy for outages and incidents, including security incidents
-* force HTTPS on all connections
-* enforce access control on our microservice infrastructure
-* encrypt user secrets and credentials and hash passwords with salts
-* regularly update our code dependencies and runtime environment to keep up with security patches
-* audit logs for suspicious activity
+* conform to regulatory requirements for personally-identifiable information (PII).
+* manage an escalation policy for outages and incidents, including security incidents.
+* force HTTPS on all connections.
+* enforce access control on our microservice infrastructure.
+* store user passwords, secrets, and credentials encrypted at rest.
+* regularly update our code dependencies and runtime environment to keep up with security patches.
+* audit logs for suspicious activity.
 
 ### What data does Relay store?
 
 Relay stores:
 
-* user account information
-* web activity usage via Fullstory
-* user-provided credentials and secrets
-* audit history and step execution output
+* user account information.
+* web activity usage via Fullstory.
+* user-provided credentials and secrets.
+* audit history and step execution output.
 
 ### Can I host Relay on-prem?
 
-No, at the moment Relay is SaaS-only. We are actively exploring feasibility of adding an on-prem connector but will not be likely to provide a self-hosted version of the product. Please [contact us](mailto:relay@puppet.com) if you're interested in working with us on defining requirements for this capability.
+No, at the moment Relay is SaaS-only. We are actively exploring the feasibility of adding an on-prem connector, but we're not likely to provide a self-hosted version of the product. Please [contact us](mailto:relay@puppet.com) if you're interested in working with us on defining requirements for this capability.
 
 ## Further reading
 
-In addition to the inline links above, if you're interested in deeper internals of the system, please read the [Integrating with Relay](integrationg-with-relay.md) doc, the [reference section](reference.md), and check out the [technical blog](https://relay.sh/).
+In addition to the inline links above, if you're interested in the deeper internals of the system, please read the [Integrating with Relay](integrationg-with-relay.md) doc, the [reference section](reference.md), and check out the [technical blog](https://relay.sh/).

--- a/docs/integrating-with-relay.md
+++ b/docs/integrating-with-relay.md
@@ -6,27 +6,27 @@ There's a growing [ecosystem of integrations](https://relay.sh/integrations/) th
 
 This may seem self-evident, but it's important to determine what your goal is _before_ you begin coding. Relay has several useful points of extensibility, and understanding the purpose of each will help you find a starting point. Integrations consist of containers that are used in different parts of Relay, which have two flavors: **steps** and **triggers**.
 
-* **Steps** - Relay runs steps, passing in parameters and secrets, as part of an automation workflow. Most of the work in Relay is done by Steps, which use an SDK to retrieve and modify a workflow's state as it executes.
-* **Triggers** - Relay supports several [types of triggers](./reference/relay-workflows.md#Triggers), which are event handlers that initiate workflow runs. The Relay service handles `push` triggers natively, but `webhook` triggers work by executing a user-defined container to handle the payload of the webhook's incoming HTTP request. Therefore, integrations that connect to Relay using webhooks need to provide a Trigger container.
+* **Steps** - Relay runs steps, passing in parameters and secrets, as part of an automation workflow. Most of the work in Relay is done by steps, which use an SDK to retrieve and modify a workflow's state as it executes.
+* **Triggers** - Relay supports several [types of triggers](./reference/relay-workflows.md#Triggers), which are event handlers that initiate workflow runs. The Relay service handles `push` triggers natively, but `webhook` triggers work by executing a user-defined container to handle the payload of the webhook's incoming HTTP request. Therefore, integrations that connect to Relay using webhooks need to provide a trigger container.
 
-Steps and Triggers come together in Workflows, YAML code written to accomplish the task you're faced with. Workflow authoring is covered in the [Using workflows](./using-workflows.md) documentation, so here we'll focus on creating and using Steps and Triggers.
+Steps and triggers come together in workflows, YAML code written to accomplish the task you're faced with. Workflow authoring is covered in the [Using workflows](./using-workflows.md) documentation, so here we'll focus on creating and using steps and triggers.
 
-## Creating Containers for Relay
+## Creating containers for Relay
 
-In its simplest form, a Relay container image runs, does some work, and then exits. It's possible to use any OCI-compliant container, as long as its entrypoint terminates with a `0` exit code upon success and a non-zero code upon failure. However, beyond "hello world" examples you'll likely want an image with more capabilities than just using `alpine:latest`. There are two possible paths here, depending on your use case.
+In its simplest form, a Relay container image runs, does some work, and then exits. It's possible to use any OCI-compliant container, as long as its entrypoint terminates with a zero exit code upon success and a non-zero code upon failure. However, beyond "hello world" examples, you'll likely want an image with more capabilities than just using `alpine:latest`. There are two possible paths here, depending on your use case.
 
 1. If the work you're trying to do can be written in a shell or Python script, use the `relaysh/core` image. This is an Alpine-based image that the Relay team maintains, which comes pre-loaded with the Relay SDK. There are `relaysh/core:latest` and `relaysh/core:latest-python` flavors available. You can use these either as a base image in your own Dockerfile or in workflows directly, by specifying an `inputFile` tag whose value is a URL to your script.
 2. If there's an existing image that's made for your integration target, you can use it as the starting point for a custom container. Adding the Relay tools in at build time will allow you to use the metadata service via either the command-line interface or code SDK.
 
 ### Using relaysh/core
 
-Using the `relaysh/core` image is the easiest option because it avoids having to build and push a custom container image, but it restricts you to providing your script in a single file. To use it, make your script accessible via https — github repositories or gists both work fine — and provide the URL to it in the `inputFile` attribute on a `step` or `trigger` definition. For very simple scripts, you can use the [`input` attribute](./reference/relay-workflows.md#input) and provide your commands as an array of shell commands.
+Using the `relaysh/core` image is the easiest option because it avoids having to build and push a custom container image, but it restricts you to providing your script in a single file. To use it, make your script accessible via HTTPS — GitHub repositories or gists both work fine — and provide the URL to it in the `inputFile` attribute on a `step` or `trigger` definition. For very simple scripts, you can use the [`input` attribute](./reference/relay-workflows.md#input) and provide your commands as an array of shell commands.
 
-There are two variants of `relaysh/core`, indicated by their tag: `relaysh/core:latest` accepts a Bash shell as input and `relaysh/core:latest-python` (as you might expect) expects a Python script. Specify which you want to use in the `image` attribute of your definition.
+There are two variants of `relaysh/core`, indicated by their tag: `relaysh/core:latest` accepts a Bash shell as input and `relaysh/core:latest-python` expects a Python script. Specify which you want to use in the `image` attribute of your definition.
 
-#### relaysh/core Shell Example
+#### relaysh/core shell example
 
-Because webhook Trigger containers need to handle a web request, the shell image isn't suitable for triggers, only steps.
+Because webhook trigger containers need to handle a web request, the shell image isn't suitable for triggers, only steps.
 
 ```yaml
 steps:
@@ -35,9 +35,9 @@ steps:
     inputFile: https://git.io/JfiwE
 ```
 
-#### relaysh/core Python Example
+#### relaysh/core Python example
 
-The Python image is usable for both steps and triggers. The following workflow receives a pushed tag from dockerhub and sends a notification with the name of the tag.
+The Python image is usable for both steps and triggers. The following workflow receives a pushed tag from Docker Hub and sends a notification with the name of the tag.
 
 ```yaml
 parameters:
@@ -64,9 +64,9 @@ steps:
 
 While it's possible to use an upstream image without modification, customizing it can greatly increase its usefulness. Adding the Relay SDK or `ni` command-line utility to the container enables access to the Relay service APIs, which allow you to retrieve and set parameters, access secrets, and use Relay's persistent logging framework. Additionally, writing a custom entrypoint allows you to control the container's behavior to ensure it runs correctly in Relay.
 
-For trigger containers, we recommend using the relaysh/core:latest-python image as your base image and adding your own code as the entrypoint. See the [Writing entrypoint code](#writing-entrypoint-code) section for details.
+For trigger containers, we recommend using the `relaysh/core:latest-python` image as your base image and adding your own code as the entrypoint. See the [Writing entrypoint code](#writing-entrypoint-code) section for details.
 
-This section assumes you're familiar with the Dockerfiles and the container build/push process.
+This section assumes you're familiar with Dockerfiles and the container build/push process.
 
 #### Adding the CLI
 
@@ -85,7 +85,7 @@ RUN set -eux ; \
     rm -fr /tmp/ni
 ```
 
-This will download, verify, and install the latest version of the CLI. To use it in your entrypoint, the `ni get` subcommand will (with no arguments) print a JSON string containing all the parameters listed in the step's `spec` section. Given a parameter to retrive, it'll print that in string form (without an enclosing json object).
+This will download, verify, and install the latest version of the CLI. To use it in your entrypoint, the `ni get` subcommand will (with no arguments) print a JSON string containing all the parameters listed in the step's `spec` section. Given a parameter to retrieve, it'll print that in string form (without an enclosing JSON object).
 
 The `ni output set` subcommand will write values back to the metadata service for use by later steps, and `ni log` will write log messages which can be helpful when debugging.
 
@@ -112,7 +112,7 @@ steps:
 
 #### Adding the SDK
 
-If you're using Python in your container, the latest version of the Relay SDK can be installed via pip in your Dockerfile:
+If you're using Python in your container, the latest version of the Relay SDK can be installed via `pip` in your Dockerfile:
 
 ```shell
 RUN pip --no-cache-dir install "https://packages.nebula.puppet.net/sdk/support/python/v1/nebula_sdk-1-py3-none-any.whl"
@@ -122,37 +122,37 @@ The SDK itself has a top-level README and inline API documentation; check out th
 
 ### Writing entrypoint code
 
-Whichever route you've chosen, at this point you've got the setup for a Relay-friendly container. The last part is probably the most interesting, because it's where you need to write enough code to make the container do your bidding. We'll handle the examples for Steps and Triggers slightly differently, since there are different APIs you'll be working with.
+Whichever route you've chosen, at this point you've got the setup for a Relay-friendly container. The last part is probably the most interesting, because it's where you need to write enough code to make the container do your bidding. We'll handle the examples for steps and triggers slightly differently, since there are different APIs you'll be working with.
 
 #### Trigger entrypoints and webhook API
 
-Under the hood, when a workflow references a webhook trigger, the Relay app will prompt the user to register the webhook on the remote service. Once it's set up, Relay associates all incoming requests to their associated trigger containers. When a request comes in, Knative launches the appropriate container and connects the incoming payload to the entrypoint, a http handler. The container's job is to:
+Under the hood, when a workflow references a webhook trigger, the Relay app will prompt the user to register the webhook on the remote service. Once it's set up, Relay associates all incoming requests to their associated trigger containers. When a request comes in, Knative launches the appropriate container and connects the incoming payload to the entrypoint, an HTTP handler. 
 
-* Start a webserver on the port specified by the environment variable `$PORT` (defaults to 8080)
-* Handle a POST request and decode the incoming payload
-* Decide whether to run the rest of the workflow
-* If so, map values from the request payload onto event data
-* Finally, send this mapping back into the Relay service as an event
+The container does the following:
+* Starts a webserver on the port specified by the environment variable `$PORT` (defaults to `8080`).
+* Handles a POST request and decode the incoming payload.
+* Decides whether to run the rest of the workflow.
+* Maps values from the request payload onto event data.
+* Sends this mapping back into the Relay service as an event.
 
 The Relay Python SDK is by far the easiest way to do this. The [Integration template repository](https://github.com/relay-integrations/template/) has a simple starting point, and there are full-featured examples for [Dockerhub push events](https://github.com/relay-integrations/relay-dockerhub/blob/master/triggers/dockerhub-trigger-image-pushed/handler.py) and [new Pagerduty incidents](https://github.com/relay-integrations/relay-pagerduty/blob/master/triggers/pagerduty-trigger-incident-triggered/handler.py). Check out the [Relay integrations on Github](https://github.com/relay-integrations/) for more ideas.
 
 #### Step entrypoints
 
-Steps have a relatively easy lot in life. They run, do some work to advance the state of the workflow, and exit. In many cases, a step can use existing scripts which you modify only enough to take advantage of the Relay service API. The [Getting started](./getting-started.md) shows an example workflow that uses the `input` map to access this API for retrieving and setting keys and values to pass data through the workflow. For more advanced uses, you'll probably need a script that uses the [ni utility](./cli/ni.md) or its [python SDK equivalent](https://github.com/puppetlabs/nebula-sdk/blob/master/support/python#accessing-data-from-the-step-spec) to get and set data. Formally, a step container running in Relay can expect:
+Steps have a relatively easy lot in life. They run, do some work to advance the state of the workflow, and exit. In many cases, a step can use existing scripts which you modify only enough to take advantage of the Relay service API. The [Getting started](./getting-started.md) shows an example workflow that uses the `input` map to access this API for retrieving and setting keys and values to pass data through the workflow. For more advanced use cases, you'll probably need a script that uses the [ni utility](./cli/ni.md) or its [python SDK equivalent](https://github.com/puppetlabs/nebula-sdk/blob/master/support/python#accessing-data-from-the-step-spec) to get and set data. 
 
-* It will be executed without persistent storage
-* Only keys declared in the step's `spec` map in the workflow will be available in the metadata service
-* It can set output values through the metadata service which will be available to later steps
-* Exiting with a zero exit code will cause the workflow run to continue
-* Exiting with a non-zero exit code will cause the workflow run to be terminated and no dependent steps will run
+Formally, a step container running in Relay can expect the following:
+* It will be executed without persistent storage.
+* Only keys declared in the step's `spec` map in the workflow will be available in the metadata service.
+* It can set output values through the metadata service which will be available to later steps.
+* Exiting with a zero exit code will cause the workflow run to continue.
+* Exiting with a non-zero exit code will cause the workflow run to be terminated and no dependent steps will run.
 
 For examples of using the `ni` utility in shell commands, see the [kustomize integration](https://github.com/relay-integrations/relay-kustomize/blob/master/steps/kustomize/step.sh); for examples of using the Python SDK, the [AWS EC2 integration](https://github.com/relay-integrations/relay-aws-ec2/tree/master/steps) has several steps of varying complexity.
 
 ### Building and publishing containers
 
-Once you've got your base image and custom code together, you can proceed with building and publishing the containers. Relay has conventions for container and integration metadata which aren't _required_ but will increase consistency and help with future compatibility. These conventions are encoded in the [template integration repo](https://github.com/relay-integrations/template), specifically:
-
-* Relay containers should be built with LABEL directives that indicate their title and description.
+Once you've got your base image and custom code together, you can proceed with building and publishing the containers. Relay has conventions for container and integration metadata which aren't _required_ but will increase consistency and help with future compatibility. These conventions are encoded in the [template integration repo](https://github.com/relay-integrations/template), specifically, Relay containers should be built with `LABEL` directives that indicate their title and description.
 
 The following Dockerfile shows this in action:
 

--- a/docs/managing-users.md
+++ b/docs/managing-users.md
@@ -1,4 +1,4 @@
-# Managing Users
+# Managing users
 
 ## Role Based Access Control (RBAC)
 Role based access control provides the ability to manage access to workflows, connections, approvals, and secrets.
@@ -18,7 +18,7 @@ In addition to permissions granted in Operator role, an Approver can also approv
 In addition to permissions granted in Approver role, an Administrator can add or modify new workflows, add or modify connections, add or modify secrets, and invite and manage users.
 
 ## Inviting new users
-You can invite new users to your Relay account by clicking "Access Control" from the left navigation. Enter an email address, the user's name, and the access level you want them to have. Invited users will receive an email invitation to confirm their account and create a password.
+You can invite new users to your Relay account by clicking **Access Control** from the left navigation. Enter an email address, the user's name, and the access level you want them to have. Invited users will receive an email invitation to confirm their account and create a password.
 
 ![Invite new users to relay](images/invite-users.gif)
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,15 +4,15 @@ Relay helps you automate your applications and infrastructure using simple workf
 
 ![Relay banner](images/relay-logo.svg)
 
-If you're using Relay for the first time, follow our guided [Getting Started](getting-started.md) tour to familiarize yourself with the concepts and learn your way around the tool.
+If you're using Relay for the first time, follow our [Getting started](getting-started.md) guide to familiarize yourself with key Relay concepts and learn your way around.
 
 To start authoring your own Relay workflows, follow these steps:
 
-1. Make sure you've got an activated account and can [log in to the Relay service](https://app.relay.sh)
-2. Install the [Relay command line interface](https://github.com/puppetlabs/relay#installation)
-3. [Set up your editor](setting-up-editor.md) for Relay authoring. This is optional but makes editing workflows lots easier!
-4. [Pick a reference workflow](reference-workflows.md) to use a starting point.
-5. Modify it to your heart's desire, then [run it on the service](using-workflows/running-a-workflow.md)
+1. Make sure you've got an activated account and can [log in to the Relay service](https://app.relay.sh).
+2. Install the [Relay command line interface](https://github.com/puppetlabs/relay#installation).
+3. (Optional) [Set up your editor](setting-up-editor.md) for Relay authoring. Although this is optional, it makes editing workflows a lot easier!
+4. [Pick a reference workflow](reference-workflows.md) to use as a starting point.
+5. Modify your reference workflow to your heart's desire, then [run it on Relay](using-workflows/running-a-workflow.md).
 
 If you're looking for reference material on workflows and steps, we've got you covered:
 

--- a/docs/reference/relay-functions.md
+++ b/docs/reference/relay-functions.md
@@ -1,6 +1,6 @@
 # Relay functions
 
-Relay provides utility functions that help you manipulate data as it passes through your workflow. They are invoked in a workflow in the value a key: `!Fn.<function> [<arguments>]`.
+Relay provides utility functions that help you manipulate data as it passes through your workflow. You can invoke a function in a workflow using the following syntax: `!Fn.<function> [<arguments>]`.
 
 ## append
 
@@ -31,9 +31,9 @@ description: !Fn.convertMarkdown [jira, !Parameter markdown]
 
 Currently supported specifications:
 
-* [jira](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
-* [slack](https://api.slack.com/reference/surfaces/formatting)
-* html
+* [`jira`](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
+* [`slack`](https://api.slack.com/reference/surfaces/formatting)
+* `html`
 
 ## jsonUnmarshal
 

--- a/docs/reference/relay-types.md
+++ b/docs/reference/relay-types.md
@@ -1,6 +1,6 @@
 # Relay types
 
-Relay's workflow dialect uses YAML "tag" notation, indicated by a `!`, to identify custom data types that the Relay service associates with code that it should run the workflow is executing. This allows workflows to have dynamic values, instead of hard coding everything directly in the YAML.  There are several top-level types described here, plus a set of data-manipulation functions accessed as `!Fn.<function>` which are [documented in the function reference](./relay-functions.md).
+Relay's workflow dialect uses YAML "tag" notation, indicated by a `!`, to identify custom data types that Relay associates with code that it should run while it is executing the workflow. This allows workflows to have dynamic values, instead of hard coding everything directly in the YAML. There are several top-level types described here, plus a set of data-manipulation functions accessed as `!Fn.<function>`, which are [documented in the function reference](./relay-functions.md).
 
 ## !Connection
 
@@ -15,15 +15,15 @@ Most workflows require some form of authentication. `!Connection` provides a way
       region: !Parameter region
 ```
 
-Then, add the required credentials for the Connection (in the example: `my-aws-account`) in the `Setup` sidebar.
+Then, add the required credentials for the connection (in the example: `my-aws-account`) in the **Settings** sidebar.
 
-Connections can be reused across Workflows. Referencing the same `!Connection` by name in another workflow will automatically use the defined connection.
+Connections can be reused across workflows. Referencing the same `!Connection` by name in another workflow will automatically use the defined connection.
 
-See also the documentation on [Adding Connections to your Workflow](../using-workflows/adding-connections.md).
+See also the documentation on [Adding connections to your workflow](../using-workflows/adding-connections.md).
 
 ## !Secret
 
-Use this to indicate the value is a named secret that's stored on the service. The value needs to exactly match the secret name. If the secret doesn't exist, the workflow will not run. Unlike Connections, Secrets are scoped to a single workflow.
+Use this to indicate the value is a named secret that's stored by Relay. The value needs to exactly match the secret name. If the secret doesn't exist, the workflow will not run. Unlike connections, secrets are scoped to a single workflow.
 
 The most common usage for `!Secret` is in the `spec` for a given step, to indicate the value needs to be looked up from the secret store:
 
@@ -78,7 +78,7 @@ For more information on outputs, see [Passing data into workflow steps](../using
 
 ## !Fn
 
-`!Fn` is short for "function". It is a special data type that indicates to the Relay service that it should run custom code (the function) with in order to produce the result. Functions allow you to manipulate data between steps and are also, when used as the value for a `when` keyword, the way Relay implements conditional execution. The general form of using functions is:
+`!Fn` is short for "function". It is a special data type that indicates to the Relay service that it should run custom code (the function) in order to produce the result. Functions allow you to manipulate data between steps and are also, when used as the value for a `when` keyword, the way Relay implements conditional execution. The general form of using functions is:
 
 ```yaml
 steps:
@@ -96,4 +96,4 @@ See the [Relay function reference](relay-functions.md) for the full list of func
 
 ## !Data
 
-`!Data` is a type that's only valid in the context of a [Trigger section of a workflow](relay-workflows.md). It allows you to extract the contents of a field from an incoming event payload for use in your workflow.
+`!Data` is a type that's only valid in the context of a [trigger section of a workflow](relay-workflows.md). It allows you to extract the contents of a field from an incoming event payload for use in your workflow.

--- a/docs/reference/relay-workflows.md
+++ b/docs/reference/relay-workflows.md
@@ -31,7 +31,8 @@ The `steps` key makes up the body of your workflow. It contains an array of step
 
 ### name
 
-(string) The name of the step. Must be unique across the workflow.
+The name of the step. Must be unique across the workflow.
+**Type:** String
 
 ```yaml
 name: echo
@@ -39,7 +40,8 @@ name: echo
 
 ### image
 
-(string) The container image and tag you're using for the step. Relay's default registry is [Docker hub](https://hub.docker.com), so if the image is hosted there you can use the short `imagename:tag` syntax. Otherwise, use the long form like `gcr.io/account/image:tag`
+The container image and tag you're using for the step. Relay's default registry is [Docker Hub](https://hub.docker.com), so if the image is hosted there you can use the short `imagename:tag` syntax. Otherwise, use the long form like `gcr.io/account/image:tag`
+**Type:** String
 
 ```yaml
 image: alpine:latest
@@ -47,11 +49,13 @@ image: alpine:latest
 
 ### spec
 
-(array) Short for 'specification'; this section provides context that's specific to the step. The contents of `spec` will depend on the implementation of the task container; programmers may find it useful to think of it as providing values to a function. For example, a step which uses the [relaysh/jira-server-step-issue-transition](https://hub.docker.com/r/relaysh/jira-server-step-issue-transition) container to close a Jira ticket requires `url` and `issue` keys in its `spec`. For a list of step containers curated by Puppet see [step containers](../step-specifications.md).
+Short for "specification"; this section provides context that's specific to the step. The contents of `spec` will depend on the implementation of the task container; programmers may find it useful to think of it as providing values to a function. For example, a step which uses the [relaysh/jira-server-step-issue-transition](https://hub.docker.com/r/relaysh/jira-server-step-issue-transition) container to close a Jira ticket requires `url` and `issue` keys in its `spec`. For a list of step containers curated by Puppet see [step containers](../step-specifications.md).
+**Type:** Array
 
 ### dependsOn
 
-(string or array of strings) As the name suggests, `dependsOn` indicates that this step depends on another step in the workflow. Each value must be a valid `name` attribute for another step. This key is useful if you need to set an explicit sequential order for your steps. Without `dependsOn` or implicit ordering requirements (see the [!Output type](../reference/relay-types.md)), Relay will run your steps in parallel to speed up execution.
+Indicates that this step depends on another step in the workflow. Each value must be a valid `name` attribute for another step. This key is useful if you need to set an explicit sequential order for your steps. Without `dependsOn` or implicit ordering requirements (see the [!Output type](../reference/relay-types.md)), Relay will run your steps in parallel to speed up execution.
+**Type:** String or array of strings
 
 ```yaml
 dependsOn:
@@ -60,11 +64,13 @@ dependsOn:
 
 ### input
 
-(array of strings) If the container is configured to accept it, you can use the `input` map to provide a list of commands that Relay passes to the entrypoint.
+If the container is configured to accept it, you can use the `input` map to provide a list of commands that Relay passes to the entrypoint.
+**Type:** Array of strings
 
 ### inputFile
 
-(string) If the container is configured to accept it, you can use the `inputFile` attribute to supply a URL to a file which Relay will download and provide as input to the entrypoint. The URL must be accessible to the public internet.
+If the container is configured to accept it, you can use the `inputFile` attribute to supply a URL to a file which Relay will download and provide as input to the entrypoint. The URL must be accessible to the public internet.
+**Type:** String
 
 ## Triggers
 
@@ -72,15 +78,17 @@ Triggers map incoming events to workflows. The `triggers` key contains an array 
 
 ### name
 
-(string) A name for this trigger; must be unique to the workflow.
+A name for this trigger; must be unique to the workflow.
+**Type:** String
 
 ### source
 
-(map) The source for the trigger is a description of the event which will cause the workflow to run. There are currently three kinds of sources available; `source` requires a `type` attribute to indicate which one to use, and each type has additional required fields.
+The source for the trigger is a description of the event which will cause the workflow to run. There are currently three kinds of sources available; `source` requires a `type` attribute to indicate which one to use, and each type has additional required fields.
+**Type:** Map
 
 #### schedule
 
-A Schedule trigger type works, as the name suggests, on a time-based schedule. It needs a key named `schedule` whose value is a string in  the standard Unix 'cron' syntax. There's a handy [crontab syntax generator](https://crontab.guru/) that can help you build a schedule if you're not familiar with cron. To determine whether Relay supports a particular advanced cron syntax, check the docs for the underlying implementation at [github.com/robfig/cron](https://github.com/robfig/cron/blob/master/doc.go).
+A schedule trigger works on a time-based schedule. It needs a key named `schedule` whose value is a string in  the standard Unix cron syntax. There's a handy [crontab syntax generator](https://crontab.guru/) that can help you build a schedule if you're not familiar with cron. To determine whether Relay supports a particular advanced cron syntax, check the docs for the underlying implementation at [github.com/robfig/cron](https://github.com/robfig/cron/blob/master/doc.go).
 
 ```yaml
 triggers:
@@ -92,7 +100,7 @@ triggers:
 
 #### webhook
 
-A Webhook trigger matches an incoming webhook payload from an external service to the workflow. Relay runs a container image in reponse to the webhook payload, so it requires an `image` field that is a reference to a container image hosted on a registry, same as the `image` field in a `step` definition.
+A webhook trigger matches an incoming webhook payload from an external service to the workflow. Relay runs a container image in response to the webhook payload, so it requires an `image` field that is a reference to a container image hosted on a registry, same as the `image` field in a `step` definition.
 
 ```yaml
 triggers:
@@ -144,7 +152,7 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 
 ### binding
 
-The `binding` key of a trigger definition maps incoming data from the event to parameters in the workflow. This allows you, for example, extract a field from the json payload of a webhook. A `binding` has one field, `parameters`, which is a map whose keys must match the names of parameters inside the workflow. The values can use [Functions](./relay-functions.md) or [Data types](./relay-types.md) in order to extract and manipulate data into the form the workflow parameter expects.
+The `binding` key of a trigger definition maps incoming data from the event to parameters in the workflow. This allows you to, for example, extract a field from the json payload of a webhook. A `binding` has one field, `parameters`, which is a map whose keys must match the names of parameters inside the workflow. The values can use [Functions](./relay-functions.md) or [Data types](./relay-types.md) in order to extract and manipulate data into the form the workflow parameter expects.
 
 The `!Data` custom type is particularly helpful here, because it will be populated with the keys from an incoming `webhook` or `push` event.
 
@@ -162,7 +170,7 @@ parameters:
     default: latest
 ```
 
- Expanding on the Docker hub example, this trigger extracts the `tag` field from the incoming webhook and maps it to the parameter `dockerTagName`, which is used in the workflow to override the default value of `latest`.
+ Expanding on the Docker Hub example, this trigger extracts the `tag` field from the incoming webhook and maps it to the parameter `dockerTagName`, which is used in the workflow to override the default value of `latest`.
 
  ### when
 
@@ -179,4 +187,4 @@ triggers:
     when: !Fn.equals[!Data environment, 'production']
 ```
 
-The [Relay functions](./relay-functions.md) reference has more examples of the `!Fn.*` syntax.
+The [Relay functions](./relay-functions.md) reference has more examples of function syntax.

--- a/docs/setting-up-editor.md
+++ b/docs/setting-up-editor.md
@@ -1,6 +1,6 @@
 # Setting up your editor for Relay
 
-Relay workflows are written in YAML that conforms to a particular specification. It can speed up the development cycle and reduce errors if your authoring environment knows about the specification, because you can get real-time validation and data type checking as you write. Here's how to set that up:
+Relay workflows are written in YAML that conforms to a particular specification. It can speed up the development cycle and reduce errors if your authoring environment knows about the specification, because you can get real-time validation and data type checking as you write. Here's how to set that up.
 
 ## Visual Studio Code
 

--- a/docs/step-specifications.md
+++ b/docs/step-specifications.md
@@ -1,6 +1,6 @@
 # Curated step containers
 
-There are a number of Relay containers available that you that can use in your workflows. For a full list of available containers and their tags, see [relaysh on Docker Hub](https://hub.docker.com/u/relaysh).
+There are a number of Relay containers available that you can use in your workflows. For a full list of available containers and their tags, see [relaysh on Docker Hub](https://hub.docker.com/u/relaysh).
 
 To see the source code for the containers or contribute your own, see the [Relay integrations](https://github.com/relay-integrations) organization on GitHub. 
 

--- a/docs/using-workflows/adding-an-approval-step.md
+++ b/docs/using-workflows/adding-an-approval-step.md
@@ -2,7 +2,7 @@
 
 Add manual approvals to your Relay workflow when you need more control over when something is deployed. For example, you could prevent a deployment to your production environment without an approval from your engineering lead.
 
-After you add an approval to your workflow, an approver can accept or reject it from the workflow run page in the Relay web interface. To respond to an approval request, the user must have Approver or Administrator level of access.
+After you add an approval to your workflow, an approver can accept or reject it from the workflow run page in the Relay web interface. To respond to an approval request, you must have Approver or Administrator level of access.
 
 Approvals are similar to regular steps, although they do not require an `image` key. Approvals consist of the following keys:
 

--- a/docs/using-workflows/adding-connections.md
+++ b/docs/using-workflows/adding-connections.md
@@ -1,16 +1,16 @@
-# Managing Connections
+# Managing connections
 
 Connections allow you to link Relay to other services you use, so that incoming events and outgoing actions can be automated across your whole toolchain.
 
 ## Adding connections
 
-To add connections, you must have the Administrator role on your account. Connections are global to the Relay account and are available to any workflows and authorized users on the account. See [Managing Users](../managing-users.md) for more on access control.
+To add connections, you must have the administrator role on your account. Connections are global to the Relay account and are available to any workflows and authorized users on the account. See [Managing Users](../managing-users.md) for more on access control.
 
-Use the "Connections" link in the left navigation bar to show currently configured connections and add new ones. Currently, Relay supports connection types of AWS, Azure, Slack, and SSH keys. If there are additional tools and services you want to provide credentials to, you can use [Secret values](./adding-secrets.md) instead of a provider-specific Connection. These work almost the same but Secrets are specific to a workflow instead of being global. (If you run into this, please [let us know via Github issues](https://github.com/puppetlabs/relay/issues/new/choose) what you'd like to see added!)
+Use the **Connections** link in the left navigation bar to show currently configured connections and add new ones. Currently, Relay supports connection types of AWS, Azure, Slack, and SSH keys. If there are additional tools and services you want to provide credentials to, you can use [secret values](./adding-secrets.md) instead of a provider-specific connection. These work almost the same, but secrets are specific to a workflow instead of being global. If you'd like us to support a specific service, please [let us know via Github issues](https://github.com/puppetlabs/relay/issues/new/choose)!
 
 ![Expand the Setup menu then choose the connection to configure](../images/adding-connections.gif)
 
-## Using Connections
+## Using connections
 
 To use a connection in a workflow, set a field's value to `!Connection` and provide a map containing the connection's name and type. For example:
 
@@ -23,7 +23,11 @@ steps:
         connection: !Connection { type: aws, name: my-aws-account }
 ```
 
-If you reference a Connection in a workflow you're viewing or editing on the web app, Relay will check that the connection actually exists and prompt you to create it if not. To set the required values for the connection, on the workflow's page, expand the "Setup" menu on the header bar, then find the connection you specified. Click the ( + ) to add the connection values. Once you create a connection, you cannot view its values again; you can only overwrite or delete them.
+If you reference a connection in a workflow you're viewing or editing on the web app, Relay will check that the connection actually exists and prompt you to create it if not. To set the required values for the connection:
+1. On the workflow's page, expand the **Setup** menu on the header bar.
+2. Find the connection you specified and click **+** to add the connection values. 
+
+Once you create a connection, you cannot view its values again; you can only overwrite or delete them.
 
 When you run a workflow, steps that need a connection request it from Relay's secret store. You can use secrets inside a step with one of the Relay SDKs. This example snippet uses the Python SDK to make use of the connection in the workflow above:
 
@@ -41,4 +45,4 @@ This is a partial snippet; [see the full step code here](https://github.com/rela
 
 ## Implementation details
 
-Secrets and Connections are very similar; see the [implementation section of the Secrets docs](./adding-secrets.md) for more information on how they work and guidance on how to use them.
+Secrets and connections are very similar; see the [implementation section of the secrets docs](./adding-secrets.md) for more information on how they work and guidance on how to use them.

--- a/docs/using-workflows/adding-secrets.md
+++ b/docs/using-workflows/adding-secrets.md
@@ -4,15 +4,15 @@ Encrypted secrets allow you to store sensitive information in Relay and make it 
 
 ## Adding secrets
 
-Add a secret to your workflow and then use Relay's web interface to store the content of the secret securely on the service. Secrets are scoped to a single workflow. To add secrets, user must be an Operator, Approver, or Administrator role.
+Add a secret to your workflow and then use Relay's web interface to store the content of the secret securely. Secrets are scoped to a single workflow. To add secrets, you must be have the Operator, Approver, or Administrator role.
 
-To set a value for the secret, on the workflow's page, expand the "Setup" menu on the header bar, then click "New Secret". Make sure the name you provide matches the name of the field in the workflow! Once you create a secret, you cannot view its value again. You can only overwrite or delete it.
+To set a value for the secret, on the workflow's page, expand the **Settings** menu on the header bar, then click **Add secret**. Make sure the name you provide matches the name of the field in the workflow! Once you create a secret, you cannot view its value again. You can only overwrite or delete it.
 
 The value you set for a secret must be a string. If you have multiple key-value pairs to pass in to the secret, or your secret is the contents of a file, you must encode the values using base64 encoding, and use the encoded string as the secret value.
 
-![Expand the Setup menu then choose "New Secret"](../images/new-secret.gif)
+![Expand the Settings menu and select Add secret](../images/new-secret.gif)
 
-## Using Secrets
+## Using secrets
 
 To add a secret to your workflow, set a field's value to the `!Secret` type and provide the secret's name. For example:
 
@@ -33,15 +33,15 @@ PASSWORD="${PASSWORD:-$(ni get -p '{.credentials}')}"
 
 ## Implementation details
 
-Relay implements Secrets and [Connections](./adding-connections.md) similarly. Relay encrypts secrets when you create them and stores them encrypted in a secure service backed by [Hashicorp Vault](https://www.vaultproject.io). The permissions between Relay's services are set up so the user-facing APIs and the web app can create, overwrite, or delete, but never display them. The service which provides metadata to workflow runs can view but not change secrets, so they're visible to the containers as workflows execute.
+Relay secrets and [connections](./adding-connections.md) have similar implementations. Relay encrypts secrets when you create them and stores the encrypted secrets in a secure service backed by [Hashicorp Vault](https://www.vaultproject.io). The permissions between Relay's services are set up so the user-facing APIs and the web app can create, overwrite, or delete, but never display secrets. The service which provides metadata to workflow runs can view but not change secrets, so they're visible to the containers as workflows execute.
 
 There are some important differences between secrets and connections.
 * Secrets are scoped to a workflow and no other workflow can access another workflow's secrets, whereas connections are reusable across workflows.
-* Secrets consist of a single string key/value pair which can be named anything that makes sense for the workflow which uses them. Connections can have a user-specified name, but the structure of them is always consistent, to enable reuse. For example, an `aws` connection will always have an `accessKeyID` field, whereas an `azure` connection will always have a `subscriptionID`.
+* Secrets consist of a single string key-value pair, which can be named anything that makes sense for the workflow which uses them. Connections can have a user-specified name, but a connection's structure is always consistent, to enable reuse. For example, an `aws` connection will always have an `accessKeyID` field, whereas an `azure` connection will always have a `subscriptionID`.
 
 As any step can request secrets, it pays to be cautious:
-- Be extra careful when printing output in steps which use secrets. Steps have plaintext access to secrets and credentials, so "echo" or "printf" debugging steps can accidentally leak their values.
+- Be extra careful when printing output in steps which use secrets. Steps have plaintext access to secrets and credentials, so `echo` or `printf` debugging steps can accidentally leak their values.
 - When creating credentials to access an external service, grant the minimum necessary credentials for the workflow to run.
-- Because the contents will be encrypted, it helps to make meaningful names for connections which indicate which account/role they are associated with.
+- Because the contents will be encrypted, it helps to make meaningful names for connections which indicate which account or role they are associated with.
 - Use service accounts over personal credentials where possible.
-- Understand the code for every step running in the workflow. Source code for Puppet-curated containers lives in the [Relay Integrations organization](https://github.com/relay-integrations)
+- Understand the code for every step running in the workflow. Source code for Puppet-curated containers lives in the [Relay integrations organization](https://github.com/relay-integrations)

--- a/docs/using-workflows/passing-data-into-workflow-steps.md
+++ b/docs/using-workflows/passing-data-into-workflow-steps.md
@@ -25,13 +25,13 @@ steps:
       apitoken: !Secret slack-token
 ```
 
-For details about the parameters map, see the [Workflow reference](../reference/relay-workflows.md)
+For details about the parameters map, see the [workflow reference](../reference/relay-workflows.md)
 
 ## Passing internal workflow data into a step
 
 If you need to pass data from one step in your workflow to another step, use the `!Output` type in the `spec` section of the step which consumes the data. The step which produces the data should use the `ni output set` command to do so, as in this example:
 
-```
+```yaml
 parameters:
   message:
     description: "The message to output from the final step"
@@ -49,4 +49,4 @@ steps:
   - echo "Hello world. Your message was $(ni get -p {.message}), and the generated output was $(ni get -p {.dynamic})"
 ```
 
-Advanced users can use the [Python SDK](https://github.com/puppetlabs/nebula-sdk/tree/master/support/python) in scripts to create and modify keys instead of running `ni`.
+You can use the [Python SDK](https://github.com/puppetlabs/nebula-sdk/tree/master/support/python) in scripts to create and modify keys instead of running `ni`.

--- a/docs/using-workflows/running-a-workflow.md
+++ b/docs/using-workflows/running-a-workflow.md
@@ -5,7 +5,7 @@ To run workflows, a user must have at least [Operator level permissions](../mana
 ## Running from the web
 Run a workflow from Relay's web interface, or use the CLI.
 
-To run a workflow from the web app, navigate to the workflow's page and click the "Run" button in the top right. Relay will prompt you for any required parameters and then launch the run.
+To run a workflow from the web app, navigate to the workflow's page and click the **Run** button in the top right. Relay will prompt you for any required parameters and then launch the run.
 
 ![Select Run from a workflow's page, fill out required parameters, then select Run](../images/running-workflow.gif)
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,11 +2,11 @@
 
 ## June 2020
 
-**New Workflows**
+**New workflows**
 We've added a bunch of new [example workflows](https://relay.sh/workflows) that you can run with one click. They span across categories such as cost optimization, security, incident response and more. Here are a couple examples:
 
 - [When a Datadog alert is triggered, create a Jira ticket](https://relay.sh/workflows/datadog-to-jira/)
-- [Run Terraform when Pull Request merged in GitHub](https://relay.sh/workflows/terraform-continuous-deployment/)
+- [Run Terraform when a Pull Request is merged in GitHub](https://relay.sh/workflows/terraform-continuous-deployment/)
 - [Restrict public S3 buckets with WRITE permissions](https://relay.sh/workflows/s3-restrict-public-write-buckets/)
 
 If there's a workflow you'd like to see, [let us know](mailto:relay@puppet.com).
@@ -16,16 +16,15 @@ We're also weekly adding more and more [integrations](https://relay.sh/integrati
 
 ## May 2020
 
-**Integration Webhook Triggers** 
+**Integration webhook triggers** 
 
 Integrations now support webhook triggers. Relay will create a webserver listening for incoming webhooks from other services and execute integration code in response. [Here's an example](https://github.com/relay-integrations/relay-github/tree/master/triggers/pull-request-merged/handler.py) of the code that Relay will run after receiving a `merge` event from a GitHub PR webook. You can contribute to an [existing integration](https://github.com/relay-integrations/relay-github) or use your own container to handle the incoming webhook! 
 
 You'll start to see a lot more integrations featuring webhook triggers for a wide variety of services that support outgoing webhooks. 
 
-
 **Connections**
 
-Connections are a new feature within Relay that allow you to link Relay to other services you use. One cool thing about connections is that they can be re-used across workflows – so configuring a second workflow that uses that connection is automatic. Find out more about [connections here](./using-workflows/adding-connections.md).
+Connections are a new feature within Relay that allow you to link Relay to other services you use. One cool thing about connections is that they can be re-used across workflows – so configuring a second workflow that uses that connection is automatic. [Find out more about connections here](./using-workflows/adding-connections.md).
 
 ## April 2020
 


### PR DESCRIPTION
## Stuff that needs to be fixed (which I didn't fix)
- The sidenav is confusing 
   - The nav titles don't match the doc titles
   - The order is confusing
   - The nav should really be using the index file instead of a hard-coded json object - maybe you could add a step that converts the index into json and use that 🤷‍♂️
- The relay image on the welcome page isn't working
- I'd suggest making `development` the default branch

## Stuff I fixed
- General language clean up: I focused on language that was redundant or vague. An example of this is the many references to "the service".
- Sentence casing for titles. Puppet docs and products (Relay included) use sentence casing.
- Consistent punctuation + grammar
- UI fields should be bolded (no quotes)
- Removed latin abbreviations like "etc"
- Removed extraneous capitalization
- Where possible, removed "user" in favor of "you"

## Other observations
I'm not a fan of the no callouts rule. Although they shouldn't be overused, they serve a valuable purpose. In most cases, we use them to call attention to something important that could easily be overlooked, or to prevent a paragraph from being overloaded with the kind of information that is useful but not a priority. I think by enforcing this, you're unnecessarily hamstringing your writers.
