### PR TITLE
Updated to support multiple data types for our custom tag

### DIFF
--- a/docs/setting-up-editor.md
+++ b/docs/setting-up-editor.md
@@ -15,18 +15,21 @@ VS Code is the primary authoring environment Relay supports. In order to get syn
         "https://raw.githubusercontent.com/puppetlabs/relay-core/master/pkg/workflow/asset/data/schemas/v1/Workflow.json": ["relay*/*.yaml"]
     },
         "yaml.customTags": [
-            "!Secret scalar",
-            "!Parameter scalar",
-            "!Output sequence",
-            "!Answer sequence",
-            "!Data scalar",
-            "!Connection map",
-            "!Fn.append sequence",
-            "!Fn.concat sequence",
-            "!Fn.equals sequence",
-            "!Fn.jsonUnmarshal sequence",
-            "!Fn.notEquals sequence",
-            "!Fn.merge sequence",
+        "!Secret scalar",
+        "!Parameter scalar",
+        "!Connection mapping",
+        "!Connection sequence",
+        "!Output mapping",
+        "!Output sequence",
+        "!Answer mapping",            
+        "!Answer sequence",            
+        "!Data scalar",
+        "!Fn.append sequence",
+        "!Fn.concat sequence",
+        "!Fn.equals sequence",            
+        "!Fn.jsonUnmarshal sequence",
+        "!Fn.notEquals sequence",
+        "!Fn.merge sequence"
         ],
     "yaml.validate": true
 }


### PR DESCRIPTION
Since redhat-developer/vscode-yaml#142 , the extension supports
multiple data types for a custom tag; since many of ours support 
either mappings or sequences, this fixes validation errors when
the user picked one type over the other.